### PR TITLE
FEATURE: Add show on dropdown option to custom topic lists

### DIFF
--- a/assets/javascripts/discourse/connectors/bread-crumbs-right/custom-topic-lists-dropdown.gjs
+++ b/assets/javascripts/discourse/connectors/bread-crumbs-right/custom-topic-lists-dropdown.gjs
@@ -19,10 +19,12 @@ export default class CustomTopicListsDropdown extends Component {
   };
 
   content =
-    this.currentUser?.custom_topic_lists.map((t) => {
-      t.id = t.path;
-      return t;
-    }) || [];
+    this.currentUser?.custom_topic_lists
+      .filter(({ showOnDropdown }) => showOnDropdown)
+      .map((t) => {
+        t.id = t.path;
+        return t;
+      }) || [];
 
   get value() {
     if (!this.router.currentRoute.params.topicListName) {

--- a/lib/discourse_custom_topic_lists/site_settings/custom_topics_schema.rb
+++ b/lib/discourse_custom_topic_lists/site_settings/custom_topics_schema.rb
@@ -45,6 +45,13 @@ module DiscourseCustomTopicLists
                 default: true,
                 format: "checkbox",
               },
+              showOnDropdown: {
+                title: "Show on dropdown",
+                type: "boolean",
+                description: "Show topic list on dropdown.",
+                default: true,
+                format: "checkbox",
+              },
               access: {
                 title: "Who can see",
                 type: "string",

--- a/spec/system/custom_topic_lists_spec.rb
+++ b/spec/system/custom_topic_lists_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "Custom Topic Lists | custom lists access", type: :system do
         "path" => "some-long-path-for-questions",
         "query" => "category:questions",
         "showOnSidebar" => true,
+        "showOnDropdown" => true,
         "access" => "1",
       },
       {
@@ -38,8 +39,29 @@ RSpec.describe "Custom Topic Lists | custom lists access", type: :system do
         "path" => "arts-and-media",
         "query" => "category:arts-media",
         "showOnSidebar" => true,
+        "showOnDropdown" => true,
         "access" => "",
       },
+      {
+        "icon" => "discourse-sparkles",
+        "name" => "Will not be shown in sidebar",
+        "bannerLabel" => "Will not be shown in sidebar",
+        "path" => "arts-and-media",
+        "query" => "category:arts-media",
+        "showOnSidebar" => false,
+        "showOnDropdown" => true,
+        "access" => "",
+      },
+      {
+        "icon" => "discourse-sparkles",
+        "name" => "Will not be shown in dropdown",
+        "bannerLabel" => "Will not be shown in dropdown",
+        "path" => "arts-and-media",
+        "query" => "category:arts-media",
+        "showOnSidebar" => true,
+        "showOnDropdown" => false,
+        "access" => "",
+      }
     )
   end
 
@@ -86,6 +108,24 @@ RSpec.describe "Custom Topic Lists | custom lists access", type: :system do
         category_banner_label = "Topic with categories related to arts and media"
 
         expect(page).to have_text(category_banner_label)
+      end
+
+      it "should not be able to see custom topic lists that are not shown in sidebar" do
+        visit "/"
+        expect(page).to have_selector(".list-drop")
+        find(".list-drop").click
+        expect(page).to have_text("New questions")
+        expect(page).to have_text("Arts and Media")
+        expect(page).not_to have_text("Will not be shown in sidebar")
+      end
+
+      it "should not be able to see custom topic lists that are not shown in dropdown" do
+        visit "/"
+        expect(page).to have_selector(".list-drop")
+        find(".list-drop").click
+        expect(page).to have_text("New questions")
+        expect(page).to have_text("Arts and Media")
+        expect(page).not_to have_text("Will not be shown in dropdown")
       end
     end
 

--- a/spec/system/custom_topic_lists_spec.rb
+++ b/spec/system/custom_topic_lists_spec.rb
@@ -112,8 +112,6 @@ RSpec.describe "Custom Topic Lists | custom lists access", type: :system do
 
       it "should not be able to see custom topic lists that are not shown in sidebar" do
         visit "/"
-        expect(page).to have_selector(".list-drop")
-        find(".list-drop").click
         expect(page).to have_text("New questions")
         expect(page).to have_text("Arts and Media")
         expect(page).not_to have_text("Will not be shown in sidebar")
@@ -122,6 +120,7 @@ RSpec.describe "Custom Topic Lists | custom lists access", type: :system do
       it "should not be able to see custom topic lists that are not shown in dropdown" do
         visit "/"
         expect(page).to have_selector(".list-drop")
+        find("div[data-section-name='custom-topic-lists']").find(".btn").click # close sidebar
         find(".list-drop").click
         expect(page).to have_text("New questions")
         expect(page).to have_text("Arts and Media")

--- a/spec/system/custom_topic_lists_spec.rb
+++ b/spec/system/custom_topic_lists_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Custom Topic Lists | custom lists access", type: :system do
         "showOnSidebar" => true,
         "showOnDropdown" => false,
         "access" => "",
-      }
+      },
     )
   end
 


### PR DESCRIPTION
I wanted to make the checkboxes side by side but ` options: {
                  grid_columns: 6,
                }` did not work, I'll continue with the checkboxes stacked