### PR TITLE
Update custom-topic-lists-banner.gjs

### DIFF
--- a/assets/javascripts/discourse/connectors/above-main-container/custom-topic-lists-banner.gjs
+++ b/assets/javascripts/discourse/connectors/above-main-container/custom-topic-lists-banner.gjs
@@ -20,7 +20,7 @@ export default class CustomTopicListsBanner extends Component {
 
   <template>
     {{#if this.customTopic}}
-    {{bodyClass "category-header"}}
+      {{bodyClass "category-header"}}
       <div class="category-title-header">
         <div class="category-title-contents">
           <div class="category-logo aspect-image"></div>
@@ -28,13 +28,17 @@ export default class CustomTopicListsBanner extends Component {
             {{#if this.customTopic.icon}}
               <div class="category-icon-widget-wrapper">
                 <div class="category-icon-widget">
-                  <span class="category-icon">{{icon this.customTopic.icon}}</span>
+                  <span class="category-icon">{{icon
+                      this.customTopic.icon
+                    }}</span>
                 </div>
               </div>
             {{/if}}
             {{this.customTopic.name}}
           </h1>
-          <div class="category-title-description">{{htmlSafe this.customTopic.description}}</div>
+          <div class="category-title-description">{{htmlSafe
+              this.customTopic.description
+            }}</div>
         </div>
       </div>
     {{/if}}

--- a/assets/javascripts/discourse/connectors/above-main-container/custom-topic-lists-banner.gjs
+++ b/assets/javascripts/discourse/connectors/above-main-container/custom-topic-lists-banner.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
+import icon from "discourse-common/helpers/d-icon";
 
 export default class CustomTopicListsBanner extends Component {
   @service router;
@@ -11,6 +12,8 @@ export default class CustomTopicListsBanner extends Component {
       return;
     }
 
+    document.body.classList.add("category-header");
+
     return this.currentUser.custom_topic_lists.find(
       (list) => list.slug === this.router.currentRoute.params.topicListName
     );
@@ -18,10 +21,20 @@ export default class CustomTopicListsBanner extends Component {
 
   <template>
     {{#if this.customTopic}}
-      <div class="custom-list-banner banner-color">
-        <div class="custom-list-banner-contents">
-          <h1>{{this.customTopic.name}}</h1>
-          <div>{{htmlSafe this.customTopic.description}}</div>
+      <div class="category-title-header">
+        <div class="category-title-contents">
+          <div class="category-logo aspect-image"></div>
+          <h1 class="category-title">
+            {{#if this.customTopic.icon}}
+              <div class="category-icon-widget-wrapper">
+                <div class="category-icon-widget">
+                  <span class="category-icon">{{icon this.customTopic.icon}}</span>
+                </div>
+              </div>
+            {{/if}}
+            {{this.customTopic.name}}
+          </h1>
+          <div class="category-title-description">{{htmlSafe this.customTopic.description}}</div>
         </div>
       </div>
     {{/if}}

--- a/assets/javascripts/discourse/connectors/above-main-container/custom-topic-lists-banner.gjs
+++ b/assets/javascripts/discourse/connectors/above-main-container/custom-topic-lists-banner.gjs
@@ -20,6 +20,8 @@ export default class CustomTopicListsBanner extends Component {
 
   <template>
     {{#if this.customTopic}}
+    {{!-- These classes are reflection of discourse-category-banners at category-banner.hbs --}}
+    {{!-- https://github.com/discourse/discourse-category-banners/javascripts/discourse/components/category-banner.hbs --}}
       {{bodyClass "category-header"}}
       <div class="category-title-header">
         <div class="category-title-contents">

--- a/assets/javascripts/discourse/connectors/above-main-container/custom-topic-lists-banner.gjs
+++ b/assets/javascripts/discourse/connectors/above-main-container/custom-topic-lists-banner.gjs
@@ -20,8 +20,8 @@ export default class CustomTopicListsBanner extends Component {
 
   <template>
     {{#if this.customTopic}}
-    {{!-- These classes are reflection of discourse-category-banners at category-banner.hbs --}}
-    {{!-- https://github.com/discourse/discourse-category-banners/javascripts/discourse/components/category-banner.hbs --}}
+      {{! These classes are reflection of discourse-category-banners at category-banner.hbs }}
+      {{! https://github.com/discourse/discourse-category-banners/javascripts/discourse/components/category-banner.hbs }}
       {{bodyClass "category-header"}}
       <div class="category-title-header">
         <div class="category-title-contents">

--- a/assets/javascripts/discourse/connectors/above-main-container/custom-topic-lists-banner.gjs
+++ b/assets/javascripts/discourse/connectors/above-main-container/custom-topic-lists-banner.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
+import bodyClass from "discourse/helpers/body-class";
 import icon from "discourse-common/helpers/d-icon";
 
 export default class CustomTopicListsBanner extends Component {
@@ -12,8 +13,6 @@ export default class CustomTopicListsBanner extends Component {
       return;
     }
 
-    document.body.classList.add("category-header");
-
     return this.currentUser.custom_topic_lists.find(
       (list) => list.slug === this.router.currentRoute.params.topicListName
     );
@@ -21,6 +20,7 @@ export default class CustomTopicListsBanner extends Component {
 
   <template>
     {{#if this.customTopic}}
+    {{bodyClass "category-header"}}
       <div class="category-title-header">
         <div class="category-title-contents">
           <div class="category-logo aspect-image"></div>

--- a/assets/stylesheets/common/common.scss
+++ b/assets/stylesheets/common/common.scss
@@ -1,5 +1,4 @@
-// Custom List Banner
-.custom-list-banner {
+.category-title-header {
   display: flex;
   justify-content: center;
   width: 100%;
@@ -7,9 +6,12 @@
   &.banner-color {
     background-color: transparent;
   }
-  .custom-list-banner-contents {
+  .category-title-contents {
     max-width: 500px;
     padding: 40px;
+  }
+  .category-title {
+    display: flex;
   }
 }
 


### PR DESCRIPTION
@Grubba27 For your consideration:

This PR attempts to match the [Category Banners](https://meta.discourse.org/t/discourse-category-banners/86241) theme component template, as it outputs a similar markup, in the same outlet: `above-main-container`.

https://github.com/discourse/discourse-category-banners/blob/eb3b1308dd7b8c5c60b89db10b2ecdf0822a8440/javascripts/discourse/components/category-banner.hbs