### PR TITLE
FIX: removes experimental setting from tests

### DIFF
--- a/spec/system/custom_topic_lists_spec.rb
+++ b/spec/system/custom_topic_lists_spec.rb
@@ -128,7 +128,6 @@ RSpec.describe "Custom Topic Lists | custom lists access", type: :system do
       end
 
       it "should be able to bulk select topics in custom topic lists" do
-        SiteSetting.experimental_topic_bulk_actions_enabled_groups = "1"
         visit "/"
         find("li[data-list-item-name='Arts and Media']").click
         expect(page).to have_css(".bulk-select")


### PR DESCRIPTION
This setting doesn’t exist anymore and was causing the test to fail.