### PR TITLE
DEV: Remove references to removed 'experimental_topics_filter' setting

### DIFF
--- a/app/controllers/discourse_custom_topic_lists/lists_controller.rb
+++ b/app/controllers/discourse_custom_topic_lists/lists_controller.rb
@@ -12,7 +12,6 @@ module ::DiscourseCustomTopicLists
     def lists_feed
       discourse_expires_in 1.minute
 
-      raise Discourse::NotFound if !SiteSetting.experimental_topics_filter
       raise Discourse::InvalidParameters.new(:topic_list_name) if !params[:topic_list_name]
       topic_query_opts = { no_definitions: !SiteSetting.show_category_definitions_in_topic_lists }
 

--- a/spec/lib/discourse_custom_topic_lists/custom_topic_list_spec.rb
+++ b/spec/lib/discourse_custom_topic_lists/custom_topic_list_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe DiscourseCustomTopicLists::CustomTopicList do
 
   before do
     SiteSetting.discourse_custom_topic_lists_enabled = true
-    SiteSetting.experimental_topics_filter = true
     SiteSettingHelper.add_json(
       {
         "icon" => "question",

--- a/spec/requests/lists_controller_spec.rb
+++ b/spec/requests/lists_controller_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe DiscourseCustomTopicLists::ListsController do
 
   before do
     SiteSetting.discourse_custom_topic_lists_enabled = true
-    SiteSetting.experimental_topics_filter = true
     SiteSettingHelper.add_json(
       {
         "icon" => "question",

--- a/spec/system/custom_topic_lists_spec.rb
+++ b/spec/system/custom_topic_lists_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe "Custom Topic Lists | custom lists access", type: :system do
 
   before do
     SiteSetting.discourse_custom_topic_lists_enabled = true
-    SiteSetting.experimental_topics_filter = true
     SiteSettingHelper.add_json(
       {
         "icon" => "question",


### PR DESCRIPTION
This setting was removed in core - https://github.com/discourse/discourse/blob/55980a2a8487eedcc7660f94702ace9ac8e9591a/db/migrate/20241206002425_drop_experimental_topics_filter_site_setting.rb#L7